### PR TITLE
Add an (un)escape option for (un)bundle

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -234,6 +234,10 @@ jsrmx bundle <dir> [output]
 - `<dir>` - Required target input directory
 - `[output]` - Optional output filename or `-` for stdout (default `-`)
 
+#### Options
+
+- `-e`, `--escape` -  List of field path to convert from nested JSON to an escaped string
+
 #### Examples
 
 We can convert a directory of `.json` files into a single `.ndjson` (newline-delimited JSON) file:
@@ -296,6 +300,7 @@ jsrmx unbundle [options] [intput] [output]
 - `-n`, `--name` - A JSON path to use for filenames
 - `-p`, `--pretty` - Pretty-print output objects (default)
 - `-c`, `--compact` - Compact single-line output objects
+- `-u`, `--unescape` - List of field paths to convert from escaped string to nested JSON
 
 #### Example
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -60,6 +60,9 @@ enum Commands {
         /// Output filename or `-` for stdout
         #[arg(default_value = "-")]
         output: Output,
+        /// String-escaped nested JSON fields to unescape
+        #[arg(short, long, value_delimiter = ',')]
+        escape: Option<Vec<String>>,
     },
     /// Unbundle single [input] file into multiple json objects
     Unbundle {
@@ -78,6 +81,9 @@ enum Commands {
         /// Pretty-print output objects
         #[arg(short, long, default_value_t = true)]
         pretty: bool,
+        /// String-escaped nested JSON fields to unescape
+        #[arg(short, long, value_delimiter = ',')]
+        unescape: Option<Vec<String>>,
     },
 }
 
@@ -128,20 +134,31 @@ fn main() {
                 log::error!("Error splitting: {e}");
             });
         }
-        Commands::Bundle { dir, output } => ndjson::bundle(&dir, &output).unwrap_or_else(|e| {
+        Commands::Bundle {
+            dir,
+            escape,
+            output,
+        } => ndjson::bundle(&dir, &output, escape.unwrap_or_default()).unwrap_or_else(|e| {
             log::error!("Error bundling: {e}");
         }),
         Commands::Unbundle {
             compact,
             input,
-            mut output,
             name,
+            mut output,
             pretty,
+            unescape,
         } => {
             if pretty && !compact {
                 output.set_pretty();
             }
-            ndjson::unbundle(&input, &output, name.as_deref()).unwrap_or_else(|e| {
+            ndjson::unbundle(
+                &input,
+                &output,
+                name.as_deref(),
+                unescape.unwrap_or_default(),
+            )
+            .unwrap_or_else(|e| {
                 log::error!("Error unbundling: {e}");
             })
         }

--- a/src/output/directory.rs
+++ b/src/output/directory.rs
@@ -22,6 +22,7 @@ impl DirectoryOutput {
     fn write_file(&self, filename: &str, content: Value) -> std::io::Result<()> {
         let mut path = self.path.clone();
         path.push(filename);
+        log::info!("Writing file {}", path.display());
         let file = OpenOptions::new()
             .write(true)
             .create(true)
@@ -57,7 +58,7 @@ impl Writeable for DirectoryOutput {
 
     fn write_entries(&self, mut entries: Vec<(String, Value)>) -> std::io::Result<()> {
         if self.path != PathBuf::from(".") {
-            log::info!("Creating directory {}", self.path.display());
+            //log::info!("Creating directory {}", self.path.display());
             create_dir_all(&self.path)?;
         }
 

--- a/src/processor.rs
+++ b/src/processor.rs
@@ -1,4 +1,6 @@
 /// Process JSON objects
 pub mod json;
+/// Encode and decode nested string-escaped JSON objects
+pub mod json_field;
 /// Process newline-delimited lists of JSON objects
 pub mod ndjson;

--- a/src/processor/json_field.rs
+++ b/src/processor/json_field.rs
@@ -1,0 +1,39 @@
+use serde_json::Value;
+
+pub enum JsonField {
+    String(String),
+    Value(Value),
+}
+
+impl JsonField {
+    pub fn unescape(self) -> Value {
+        match self {
+            Self::String(string) => {
+                serde_json::from_str(&string.replace("\\\"", "\"")).unwrap_or(Value::Null)
+            }
+            Self::Value(json) => json,
+        }
+    }
+
+    pub fn escape(self) -> Value {
+        match self {
+            Self::String(string) => Value::String(string),
+            Self::Value(json) => Value::String(json.to_string()),
+        }
+    }
+}
+
+impl From<String> for JsonField {
+    fn from(string: String) -> Self {
+        Self::String(string)
+    }
+}
+
+impl From<Value> for JsonField {
+    fn from(json: Value) -> Self {
+        match json {
+            Value::String(string) => Self::String(string),
+            _ => Self::Value(json),
+        }
+    }
+}


### PR DESCRIPTION
Adds an `--escape` option on the `bundle` command to convert nested JSON objects into escaped strings.
Adds an `--unescape` option to the `unbundle` command to convert escaped strings into nested JSON objects.

This is helpful when dealing with `.ndjson` files that encode objects as escaped strings, like the [Kibana saved objects API](https://www.elastic.co/docs/api/doc/kibana/v8/operation/operation-bulkgetsavedobjects).

Example to `unbundle` Kibana saved objects and unescape listed field strings into nested JSON objects

```sh
jsrmx unbundle export.ndjson export/ --name=attributes.title --unescape=attributes.controlGroupInput.ignoreParentSettingsJSON,attributes.controlGroupInput.panelsJSON,attributes.fieldAttrs,attributes.kibanaSavedObjectMeta.searchSourceJSON,attributes.optionsJSON,attributes.panelsJSON,attributes.visState
```

Example to bundle a directory of Kibana saved objects into a single `.ndjson` file and escape listed nested JSON fields into strings

```sh
jsrmx bundle export/ import.ndjson --escape=attributes.controlGroupInput.ignoreParentSettingsJSON,attributes.controlGroupInput.panelsJSON,attributes.fieldAttrs,attributes.kibanaSavedObjectMeta.searchSourceJSON,attributes.optionsJSON,attributes.panelsJSON,attributes.visState
 ```