### PR TITLE
Refactor ouput to use trait objects

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -122,7 +122,7 @@ fn main() {
             }
             output
                 .read()
-                .expect("Error acquiring write lock on output")
+                .expect("Error acquiring read lock on output")
                 .append(merged_object)
                 .unwrap_or_else(|e| log::error!("Error writing to output: {e}"));
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -115,11 +115,14 @@ fn main() {
             let entries = input.get_entries(sort);
             let merged_object = json::merge(entries, filter);
             if pretty && !compact {
-                output.write().unwrap().set_pretty(true);
+                output
+                    .write()
+                    .expect("Error acquiring write lock on output")
+                    .set_pretty(true);
             }
             output
                 .read()
-                .unwrap()
+                .expect("Error acquiring write lock on output")
                 .append(merged_object)
                 .unwrap_or_else(|e| log::error!("Error writing to output: {e}"));
         }
@@ -131,13 +134,16 @@ fn main() {
             pretty,
         } => {
             if pretty && !compact {
-                output.write().unwrap().set_pretty(true);
+                output
+                    .write()
+                    .expect("Error acquiring write lock on output")
+                    .set_pretty(true);
             };
             let object = input.get_object().expect("Error reading input: {input:?}");
             let entries = json::split(object, filter);
             output
                 .read()
-                .unwrap()
+                .expect("Error acquiring read lock on output")
                 .write_entries(entries)
                 .unwrap_or_else(|e| {
                     log::error!("Error splitting: {e}");
@@ -162,7 +168,10 @@ fn main() {
             unescape,
         } => {
             if pretty && !compact {
-                output.write().unwrap().set_pretty(true);
+                output
+                    .write()
+                    .expect("Error acquiring write lock on output")
+                    .set_pretty(true);
             }
             NdjsonUnbundler::new(input, output.0, unescape)
                 .unbundle(name, r#type)

--- a/src/main.rs
+++ b/src/main.rs
@@ -153,7 +153,7 @@ fn main() {
             dir,
             escape,
             output,
-        } => NdjsonBundler::new(dir, output.0)
+        } => NdjsonBundler::new(dir, output)
             .bundle(escape)
             .unwrap_or_else(|e| {
                 log::error!("Error bundling: {e}");
@@ -173,7 +173,7 @@ fn main() {
                     .expect("Error acquiring write lock on output")
                     .set_pretty(true);
             }
-            NdjsonUnbundler::new(input, output.0, unescape)
+            NdjsonUnbundler::new(input, output, unescape)
                 .unbundle(name, r#type)
                 .unwrap_or_else(|e| {
                     log::error!("Error unbundling: {e}");

--- a/src/output.rs
+++ b/src/output.rs
@@ -5,12 +5,11 @@ use directory::DirectoryOutput;
 use file::FileOutput;
 use stream::StreamOutput;
 
-use serde::Serialize;
 use serde_json::Value;
 use std::path::{Path, PathBuf};
 
 trait Writeable {
-    fn append<T: Serialize>(&self, content: T) -> std::io::Result<()>;
+    fn append(&self, content: Value) -> std::io::Result<()>;
     fn set_pretty(&mut self, pretty: bool);
     fn write_entries(&self, entries: Vec<(String, Value)>) -> std::io::Result<()>;
 }
@@ -23,7 +22,7 @@ pub enum Output {
 }
 
 impl Output {
-    pub fn append<T: Serialize>(&self, content: T) -> std::io::Result<()> {
+    pub fn append(&self, content: Value) -> std::io::Result<()> {
         match self {
             Self::Directory(output) => output.append(content),
             Self::File(output) => output.append(content),

--- a/src/output.rs
+++ b/src/output.rs
@@ -12,7 +12,6 @@ use std::path::{Path, PathBuf};
 trait Writeable {
     fn append<T: Serialize>(&self, content: T) -> std::io::Result<()>;
     fn set_pretty(&mut self, pretty: bool);
-    fn write<T: Serialize>(&self, content: T) -> std::io::Result<()>;
     fn write_entries(&self, entries: Vec<(String, Value)>) -> std::io::Result<()>;
 }
 
@@ -29,14 +28,6 @@ impl Output {
             Self::Directory(output) => output.append(content),
             Self::File(output) => output.append(content),
             Self::Stdout(output) => output.append(content),
-        }
-    }
-
-    pub fn write<T: Serialize>(&self, content: T) -> std::io::Result<()> {
-        match self {
-            Self::Directory(output) => output.write(content),
-            Self::File(output) => output.write(content),
-            Self::Stdout(output) => output.write(content),
         }
     }
 

--- a/src/output.rs
+++ b/src/output.rs
@@ -9,7 +9,7 @@ use stream::StreamOutput;
 use serde_json::Value;
 use std::{
     ops::Deref,
-    path::{Path, PathBuf},
+    path::PathBuf,
     sync::{Arc, RwLock},
 };
 
@@ -20,84 +20,6 @@ pub trait Appendable: Writeable {
 pub trait Writeable: Send + Sync {
     fn set_pretty(&mut self, pretty: bool);
     fn write_entries(&self, entries: Vec<(String, Value)>) -> std::io::Result<()>;
-}
-
-#[derive(Clone, Debug)]
-pub enum Output {
-    Directory(DirectoryOutput),
-    File(FileOutput),
-    Stdout(StreamOutput),
-}
-
-impl Output {
-    pub fn append(&self, content: Value) -> std::io::Result<()> {
-        match self {
-            Self::Directory(_) => Err(std::io::Error::new(
-                std::io::ErrorKind::Other,
-                "Cannot append to a directory output",
-            )),
-            Self::File(output) => output.append(content),
-            Self::Stdout(output) => output.append(content),
-        }
-    }
-
-    pub fn set_pretty(&mut self) {
-        match self {
-            Self::Directory(output) => output.set_pretty(true),
-            Self::File(output) => output.set_pretty(true),
-            Self::Stdout(output) => output.set_pretty(true),
-        }
-    }
-
-    pub fn write_entries(&self, entries: Vec<(String, Value)>) -> std::io::Result<()> {
-        match self {
-            Self::Directory(output) => output.write_entries(entries),
-            Self::File(output) => output.write_entries(entries),
-            Self::Stdout(output) => output.write_entries(entries),
-        }
-    }
-}
-
-impl AsRef<Path> for Output {
-    fn as_ref(&self) -> &Path {
-        match self {
-            Output::Directory(output) => output.path.as_path(),
-            Output::File(output) => output.path.as_path(),
-            Output::Stdout(_) => Path::new("-"),
-        }
-    }
-}
-
-impl std::fmt::Display for Output {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        match self {
-            Output::Directory(output) => write!(f, "{}", output.path.display()),
-            Output::File(output) => write!(f, "{}", output.path.display()),
-            Output::Stdout(_) => write!(f, "-"),
-        }
-    }
-}
-
-impl std::str::FromStr for Output {
-    type Err = String;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        if s == "-" {
-            return Ok(Output::Stdout(StreamOutput::new(false)));
-        }
-
-        let path = PathBuf::from(s);
-        if path.is_dir() {
-            Ok(Output::Directory(DirectoryOutput::new(path, false)))
-        } else if path.extension().is_none() {
-            Ok(Output::Directory(DirectoryOutput::new(path, false)))
-        } else if path.is_file() {
-            Ok(Output::File(FileOutput::new(path, false)))
-        } else {
-            log::info!("Creating file: {}", &path.display());
-            Ok(Output::File(FileOutput::new(path, false)))
-        }
-    }
 }
 
 #[derive(Clone)]

--- a/src/output.rs
+++ b/src/output.rs
@@ -132,3 +132,38 @@ impl Deref for JsonAppendableOutput {
         &self.0
     }
 }
+
+#[derive(Clone)]
+pub struct JsonWritableOutput(pub Arc<RwLock<dyn Writeable>>);
+
+impl std::str::FromStr for JsonWritableOutput {
+    type Err = Report;
+
+    fn from_str(input: &str) -> Result<Self, Self::Err> {
+        match input {
+            "-" => Ok(JsonWritableOutput(Arc::new(RwLock::new(
+                StreamOutput::new(false),
+            )))),
+            input => {
+                let path = PathBuf::from(input);
+                if path.is_dir() {
+                    Ok(JsonWritableOutput(Arc::new(RwLock::new(
+                        DirectoryOutput::new(path, false),
+                    ))))
+                } else {
+                    Ok(JsonWritableOutput(Arc::new(RwLock::new(FileOutput::new(
+                        path, false,
+                    )))))
+                }
+            }
+        }
+    }
+}
+
+impl Deref for JsonWritableOutput {
+    type Target = Arc<RwLock<dyn Writeable>>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}

--- a/src/output.rs
+++ b/src/output.rs
@@ -8,8 +8,11 @@ use stream::StreamOutput;
 use serde_json::Value;
 use std::path::{Path, PathBuf};
 
-trait Writeable {
+trait Appendable {
     fn append(&self, content: Value) -> std::io::Result<()>;
+}
+
+trait Writeable {
     fn set_pretty(&mut self, pretty: bool);
     fn write_entries(&self, entries: Vec<(String, Value)>) -> std::io::Result<()>;
 }
@@ -24,7 +27,10 @@ pub enum Output {
 impl Output {
     pub fn append(&self, content: Value) -> std::io::Result<()> {
         match self {
-            Self::Directory(output) => output.append(content),
+            Self::Directory(_) => Err(std::io::Error::new(
+                std::io::ErrorKind::Other,
+                "Cannot append to a directory output",
+            )),
             Self::File(output) => output.append(content),
             Self::Stdout(output) => output.append(content),
         }

--- a/src/output/directory.rs
+++ b/src/output/directory.rs
@@ -1,6 +1,5 @@
 use super::Writeable;
 use rayon::prelude::*;
-use serde::Serialize;
 use serde_json::Value;
 use std::{
     fs::{create_dir_all, OpenOptions},
@@ -38,7 +37,7 @@ impl DirectoryOutput {
 }
 
 impl Writeable for DirectoryOutput {
-    fn append<T: Serialize>(&self, _content: T) -> std::io::Result<()> {
+    fn append(&self, _content: Value) -> std::io::Result<()> {
         Err(std::io::Error::new(
             std::io::ErrorKind::Other,
             "Cannot append to a directory output",

--- a/src/output/directory.rs
+++ b/src/output/directory.rs
@@ -49,13 +49,6 @@ impl Writeable for DirectoryOutput {
         self.pretty = pretty;
     }
 
-    fn write<T: Serialize>(&self, _content: T) -> std::io::Result<()> {
-        Err(std::io::Error::new(
-            std::io::ErrorKind::Other,
-            "Cannot write to a directory output",
-        ))
-    }
-
     fn write_entries(&self, mut entries: Vec<(String, Value)>) -> std::io::Result<()> {
         if self.path != PathBuf::from(".") {
             //log::info!("Creating directory {}", self.path.display());

--- a/src/output/directory.rs
+++ b/src/output/directory.rs
@@ -37,13 +37,6 @@ impl DirectoryOutput {
 }
 
 impl Writeable for DirectoryOutput {
-    fn append(&self, _content: Value) -> std::io::Result<()> {
-        Err(std::io::Error::new(
-            std::io::ErrorKind::Other,
-            "Cannot append to a directory output",
-        ))
-    }
-
     fn set_pretty(&mut self, pretty: bool) {
         self.pretty = pretty;
     }

--- a/src/output/file.rs
+++ b/src/output/file.rs
@@ -30,20 +30,6 @@ impl Writeable for FileOutput {
         self.pretty = pretty;
     }
 
-    fn write<T: Serialize>(&self, content: T) -> std::io::Result<()> {
-        let mut file = OpenOptions::new()
-            .write(true)
-            .create(true)
-            .truncate(true)
-            .open(&self.path)?;
-        let body = if self.pretty {
-            serde_json::to_string_pretty(&content)?
-        } else {
-            serde_json::to_string(&content)?
-        };
-        Ok(file.write_all(body.as_bytes())?)
-    }
-
     fn write_entries(&self, entries: Vec<(String, Value)>) -> std::io::Result<()> {
         let mut guard = self.writer.lock().expect("Failed to get writer lock");
         for (key, value) in entries {

--- a/src/output/file.rs
+++ b/src/output/file.rs
@@ -1,4 +1,4 @@
-use super::Writeable;
+use super::{Appendable, Writeable};
 use serde_json::Value;
 use std::{
     fs::{File, OpenOptions},
@@ -14,7 +14,7 @@ pub struct FileOutput {
     pub path: PathBuf,
 }
 
-impl Writeable for FileOutput {
+impl Appendable for FileOutput {
     fn append(&self, content: Value) -> std::io::Result<()> {
         let mut guard = self.writer.lock().expect("Failed to get writer lock");
         match self.pretty {
@@ -24,7 +24,9 @@ impl Writeable for FileOutput {
         writeln!(&mut *guard)?;
         Ok(())
     }
+}
 
+impl Writeable for FileOutput {
     fn set_pretty(&mut self, pretty: bool) {
         self.pretty = pretty;
     }

--- a/src/output/file.rs
+++ b/src/output/file.rs
@@ -1,5 +1,4 @@
 use super::Writeable;
-use serde::Serialize;
 use serde_json::Value;
 use std::{
     fs::{File, OpenOptions},
@@ -16,7 +15,7 @@ pub struct FileOutput {
 }
 
 impl Writeable for FileOutput {
-    fn append<T: Serialize>(&self, content: T) -> std::io::Result<()> {
+    fn append(&self, content: Value) -> std::io::Result<()> {
         let mut guard = self.writer.lock().expect("Failed to get writer lock");
         match self.pretty {
             true => serde_json::to_writer_pretty(&mut *guard, &content)?,

--- a/src/output/stream.rs
+++ b/src/output/stream.rs
@@ -1,4 +1,4 @@
-use super::Writeable;
+use super::{Appendable, Writeable};
 use serde_json::Value;
 use std::io::stdout;
 
@@ -13,7 +13,7 @@ impl StreamOutput {
     }
 }
 
-impl Writeable for StreamOutput {
+impl Appendable for StreamOutput {
     fn append(&self, content: Value) -> std::io::Result<()> {
         match self.pretty {
             true => serde_json::to_writer_pretty(stdout(), &content)?,
@@ -22,7 +22,9 @@ impl Writeable for StreamOutput {
         println!();
         Ok(())
     }
+}
 
+impl Writeable for StreamOutput {
     fn set_pretty(&mut self, pretty: bool) {
         self.pretty = pretty;
     }

--- a/src/output/stream.rs
+++ b/src/output/stream.rs
@@ -28,14 +28,6 @@ impl Writeable for StreamOutput {
         self.pretty = pretty;
     }
 
-    fn write<T: Serialize>(&self, content: T) -> std::io::Result<()> {
-        match self.pretty {
-            true => serde_json::to_writer_pretty(stdout(), &content)?,
-            false => serde_json::to_writer(stdout(), &content)?,
-        }
-        Ok(())
-    }
-
     fn write_entries(&self, mut entries: Vec<(String, Value)>) -> std::io::Result<()> {
         for (key, value) in entries.drain(..) {
             let entry = serde_json::json!({key: value});

--- a/src/output/stream.rs
+++ b/src/output/stream.rs
@@ -1,5 +1,4 @@
 use super::Writeable;
-use serde::Serialize;
 use serde_json::Value;
 use std::io::stdout;
 
@@ -15,7 +14,7 @@ impl StreamOutput {
 }
 
 impl Writeable for StreamOutput {
-    fn append<T: Serialize>(&self, content: T) -> std::io::Result<()> {
+    fn append(&self, content: Value) -> std::io::Result<()> {
         match self.pretty {
             true => serde_json::to_writer_pretty(stdout(), &content)?,
             false => serde_json::to_writer(stdout(), &content)?,

--- a/src/processor/ndjson.rs
+++ b/src/processor/ndjson.rs
@@ -1,20 +1,18 @@
-use std::sync::{Arc, RwLock};
-
 use super::json_field::JsonField;
 use crate::{
     input::{InputDirectory, JsonReaderInput, JsonSource},
-    output::{Appendable, Writeable},
+    output::{JsonAppendableOutput, JsonWritableOutput},
 };
 use eyre::{eyre, Result};
 use serde_json::Value;
 
 pub struct NdjsonBundler {
     input: InputDirectory,
-    output: Arc<RwLock<dyn Appendable>>,
+    output: JsonAppendableOutput,
 }
 
 impl NdjsonBundler {
-    pub fn new(input: InputDirectory, output: Arc<RwLock<dyn Appendable>>) -> Self {
+    pub fn new(input: InputDirectory, output: JsonAppendableOutput) -> Self {
         Self { input, output }
     }
 
@@ -61,14 +59,14 @@ impl NdjsonBundler {
 
 pub struct NdjsonUnbundler {
     input: JsonReaderInput,
-    output: Arc<RwLock<dyn Writeable>>,
+    output: JsonWritableOutput,
     unescape_fields: Option<Vec<String>>,
 }
 
 impl NdjsonUnbundler {
     pub fn new(
         input: JsonReaderInput,
-        output: Arc<RwLock<dyn Writeable>>,
+        output: JsonWritableOutput,
         unescape_fields: Option<Vec<String>>,
     ) -> Self {
         Self {

--- a/src/processor/ndjson.rs
+++ b/src/processor/ndjson.rs
@@ -5,6 +5,7 @@ use crate::{
     input::{InputDirectory, JsonReaderInput, JsonSource},
     output::{Appendable, Writeable},
 };
+use eyre::{eyre, Result};
 use serde_json::Value;
 
 pub struct NdjsonBundler {
@@ -24,7 +25,7 @@ impl NdjsonBundler {
     /// * `dir` - A reference to a `PathBuf` representing the directory containing JSON files.
     /// * `output` - A reference to an `Output` where the bundled JSON will be written.
 
-    pub fn bundle(&self, json_fields: Option<Vec<String>>) -> std::io::Result<()> {
+    pub fn bundle(&self, json_fields: Option<Vec<String>>) -> Result<()> {
         self.read_entries_to_output(json_fields)
     }
 
@@ -34,17 +35,17 @@ impl NdjsonBundler {
     ///
     /// * `dir` - A reference to a `PathBuf` representing the directory containing JSON files.
     /// * `output` - A reference to an `Output` where the JSON data will be appended.
-    ///
-    /// # Errors
-    ///
-    /// Returns an `std::io::Error` if any file cannot be processed or if reading fails.
 
-    fn read_entries_to_output(&self, json_fields: Option<Vec<String>>) -> std::io::Result<()> {
+    fn read_entries_to_output(&self, json_fields: Option<Vec<String>>) -> Result<()> {
         log::debug!("Escaping fields: {:?}", json_fields);
+        let output = self
+            .output
+            .read()
+            .map_err(|_| eyre!("Error acquiring read lock on output"))?;
         self.input
             .get_entries(false)
             .drain(..)
-            .map(|(_name, mut json)| {
+            .try_for_each(|(_name, mut json)| {
                 if let Some(ref json_fields) = json_fields {
                     json_fields.iter().for_each(|field| {
                         if let Some(value) = json.pointer_mut(&dots_to_slashes(field)) {
@@ -53,9 +54,8 @@ impl NdjsonBundler {
                         }
                     });
                 }
-                self.output.read().unwrap().append(json)
+                output.append(json).map_err(|e| eyre!(e))
             })
-            .collect()
     }
 }
 
@@ -86,11 +86,7 @@ impl NdjsonUnbundler {
     /// * `output` - A reference to an `Output` where the JSON files will be written.
     /// * `name` - An optional name for the JSON objects, used as a key to extract values.
 
-    pub fn unbundle(
-        &self,
-        name: Option<Vec<String>>,
-        type_field: Option<String>,
-    ) -> std::io::Result<()> {
+    pub fn unbundle(&self, name: Option<Vec<String>>, type_field: Option<String>) -> Result<()> {
         let mut i: usize = 0;
         let name_list = match name {
             Some(list) => list
@@ -125,7 +121,10 @@ impl NdjsonUnbundler {
                 Ok(mut json) => {
                     self.unescape_fields(&mut json);
                     let entry = vec![(name_entry(i, &json), json)];
-                    self.output.read().unwrap().write_entries(entry)?
+                    self.output
+                        .read()
+                        .map_err(|_| eyre!("Error acquiring read lock on output"))?
+                        .write_entries(entry)?
                 }
                 Err(e) if serde_json::Error::is_eof(&e) => break,
                 Err(e) => log::error!("Failed to parse line {}: {}", i, e),

--- a/src/processor/ndjson.rs
+++ b/src/processor/ndjson.rs
@@ -3,7 +3,7 @@ use std::sync::{Arc, RwLock};
 use super::json_field::JsonField;
 use crate::{
     input::{InputDirectory, JsonReaderInput, JsonSource},
-    output::{Appendable, Output},
+    output::{Appendable, Writeable},
 };
 use serde_json::Value;
 
@@ -61,14 +61,14 @@ impl NdjsonBundler {
 
 pub struct NdjsonUnbundler {
     input: JsonReaderInput,
-    output: Output,
+    output: Arc<RwLock<dyn Writeable>>,
     unescape_fields: Option<Vec<String>>,
 }
 
 impl NdjsonUnbundler {
     pub fn new(
         input: JsonReaderInput,
-        output: Output,
+        output: Arc<RwLock<dyn Writeable>>,
         unescape_fields: Option<Vec<String>>,
     ) -> Self {
         Self {
@@ -125,7 +125,7 @@ impl NdjsonUnbundler {
                 Ok(mut json) => {
                     self.unescape_fields(&mut json);
                     let entry = vec![(name_entry(i, &json), json)];
-                    self.output.write_entries(entry)?
+                    self.output.read().unwrap().write_entries(entry)?
                 }
                 Err(e) if serde_json::Error::is_eof(&e) => break,
                 Err(e) => log::error!("Failed to parse line {}: {}", i, e),


### PR DESCRIPTION
Instead of using an `Output` enum, we are now using trait objects instead.  Each concert output type implements the `Writable` and/or `Appendable` trait(s). Then, we use trait objects to accept various output types as Clap arguments.

This approach has a few benefits:
- It mirrors the same approach used for input types, which makes the codebase easier to reason about imo.
- It removes verbose match logic and deeply nested errors. Previously, the `DirectoryOutput` concrete type would throw an error if `write` or `append` was called. This makes the codebase hard to reason about. If a given type implements some trait, then I expect all the trait methods to work. 
- Using trait objects allows us to accept a list of various output types in the future. Not sure if this functionality will be needed though. 


**Note:** The `append` method has been updated to accept a `Value` type instead of `T: Serialize`. This is done to make the trait dyn compatible.
**Note:** I removed the `write` method because it wasn't used anywhere. 